### PR TITLE
feat: update GTM template to support JS agent v4

### DIFF
--- a/.changeset/template-js-agent-v4.md
+++ b/.changeset/template-js-agent-v4.md
@@ -1,0 +1,14 @@
+---
+'@fingerprintjs/fingerprintjs-pro-gtm': major
+---
+
+Update GTM template to support JS agent v4. This is a breaking change.
+Because the template now uses a different contract for the GTM `dataLayer`, existing GTM tags that use the previous template cannot be updated in place. However, the changes do allow new tags to be created with this template that will not interfere with existing GTM tags.
+
+- Update the `Tag type` parameter to use JS agent v4 terminology.
+- Replace the `Script Url Pattern` and `Endpoint` parameters with the `Endpoints` table.
+- Remove the `Extended result` parameter. It is no longer needed for JS agent v4.
+- Change the default result name to `FingerprintResult` from `FingerprintJSProResult`.
+- Rename custom event `FingerprintJSPro.loaded` to `Fingerprint.started`.
+- Rename custom event `FingerprintJSPro.identified` to `Fingerprint.identified`.
+- The result set in the GTM `dataLayer` uses the JS agent v4 result shape. See the [v4 get function documentation](https://docs.fingerprint.com/reference/js-agent-v4-get-function#get-response-fields) for details.

--- a/README.md
+++ b/README.md
@@ -25,35 +25,33 @@ For step-by-step instructions on using this integration, see the full [Google Ta
 1. [Sign up](https://dashboard.fingerprint.com/signup) for a Fingerprint Pro account if you haven't already.
 2. Import this `template.tpl` from [latest release](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/releases) into your Google Tag Manager workspace.
 3. Add a Fingerprint Pro tag to your website. You will need your public API key and workspace region.
-4. Use the `FingerprintJSProResult` or your own *Custom result name* to access the Fingerprint Pro result in GTM's `dataLayer`.
-5. Use `FingerprintJSPro.loaded` and `FingerprintJSPro.identified` to create custom events and trigger actions after the JS agent is loaded or the visitor is identified. 
+4. Use the `FingerprintResult` or your own *Custom result name* to access the Fingerprint Pro result in GTM's `dataLayer`.
+5. Use the `Fingerprint.started` and `Fingerprint.identified` event names to create custom events and trigger actions after the JS agent is loaded or the visitor is identified.
 
 ## Template Fields
 
 For more information and the full API reference, see [Fingerprint Pro JS Agent](https://dev.fingerprint.com/docs/js-agent) in our documentation.
 
 `Tag type` – The way you want to use the tag. There are 3 options:
-  - `Load and identify` – the default behavior. Load the JS agent and identify the browser immediately. If you want to load the JS agent first and identify the browser later based on some event, use two separate `Load` and `Identify` Fingerprint Pro tags. 
-  - `Load` – only load the JS Agent.
-  - `Identify` – identify the browser. The JS Agent must be loaded before. You can collect additional metadata data first and then trigger this tag with the metadata inside `linkedId` or `tag`.
+  - `Start and identify` – the default behavior. Start the JS agent and identify the browser immediately. If you want to start the JS agent first and identify the browser later based on some event, use two separate `Start` and `Identify` Fingerprint Pro tags.
+  - `Start` – only load the JS Agent.
+  - `Identify` – identify the browser. The JS Agent must be started before. You can collect additional metadata data first and then trigger this tag with the metadata inside `linkedId` or `tag`.
 
-`Public API key` - Your public API key that authenticates the agent with the API.
+`Public API key` - Your public API key that authenticates the agent with the Fingerprint API.
 
 `Region` - The [region](https://dev.fingerprint.com/docs/regions) of your subscription.
 
-`Endpoint` - This parameter should only be used with Custom subdomain setup or Proxy integration. Specify your custom endpoint here.
+`endpoints` - This parameter should only be used with the custom subdomain or proxy integrations. Specify the API endpoint URL for those integrations in this field.
 
 `tag` - a customer-provided value or an object that will be saved together with the identification event and will be returned back to you in a webhook message or when you search for the visit in the server API.
 
 `linkedId` - is a way of linking current identification event with a custom identifier. This will allow you to filter visit information when using the [Server API](https://dev.fingerprint.com/docs/server-api)
 
-`Extended result` - The response object includes a confidence score field representing the probability of accurate identification. The extended response object also includes several fields with useful timestamps related to a visitor. See more information on `firstSeenAt/lastSeenAt` timestamps [here](https://dev.fingerprint.com/docs/useful-timestamps).
-
 `Result custom name` - you can specify the result field name in `dataLayer`.
 
 ## Limitations
 
-Some advanced JavaScript agent properties (`tlsEndpoint`, `disableTls`, and `storageKey`) are not currently supported. If you require to use these features in the GTM, please contact [support](mailto:support@fingerprint.com).
+Some advanced JavaScript agent properties (`storageKeyPrefix` and `cache`) are not currently supported. If you require to use these features in the GTM, please contact [support](mailto:support@fingerprint.com).
 
 Ad-blocking browser extensions such as AdBlock, uBlock Origin, etc., can block all scripts served by Google Tag Manager, including Fingerprint. If this is a problem for your use case, see Google Tag Manager documentation for [Server-side tagging](https://developers.google.com/tag-platform/tag-manager/server-side) and [Custom domain configuration](https://developers.google.com/tag-platform/tag-manager/server-side/custom-domain).
 

--- a/template.tpl
+++ b/template.tpl
@@ -1,4 +1,11 @@
-﻿___INFO___
+﻿___TERMS_OF_SERVICE___
+
+By creating or modifying this file you agree to Google Tag Manager's Community
+Template Gallery Developer Terms of Service available at
+https://developers.google.com/tag-manager/gallery-tos (or such other URL as
+Google may provide), as modified from time to time.
+
+___INFO___
 
 {
   "type": "TAG",

--- a/template.tpl
+++ b/template.tpl
@@ -1,19 +1,11 @@
-﻿___TERMS_OF_SERVICE___
-
-By creating or modifying this file you agree to Google Tag Manager's Community
-Template Gallery Developer Terms of Service available at
-https://developers.google.com/tag-manager/gallery-tos (or such other URL as
-Google may provide), as modified from time to time.
-
-
-___INFO___
+﻿___INFO___
 
 {
   "type": "TAG",
   "id": "cvt_temp_public_id",
   "version": 1,
   "securityGroups": [],
-  "displayName": "Fingerprint Pro",
+  "displayName": "Fingerprint",
   "categories": [
     "ANALYTICS"
   ],
@@ -22,7 +14,7 @@ ___INFO___
     "displayName": "",
     "thumbnail": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAGAAAABgCAYAAADimHc4AAAACXBIWXMAAAsTAAALEwEAmpwYAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAA6aSURBVHgB7V3dddu4Eh6ApO+ek921VIGVCqJUEHnj7Nm3OBXEriBOBXEqiFOB7QrivN2zsTdKBZErsFKB5H3KNUngzoCULYIA+KufB33nJBYpEKIwwMw3P6AANthggw022GCDDTbYYIMNNlgqGKwhJgPoQBD0AEQfJOtxyXckkz28255qINO/OhiM8b0pvsJ/bCql/ME53AgpryGKRt2hem+tsBYCmAx+6UEQDrjwnkkuB9YBbgolIDbiXF7EEq67X8IRrBgrE8Bkz8eBZvuMw8uFDXgRUCBMwFAwed69jIawAixVAPeDzuRr/OgOrBNmwuDwcZkrYykCmDz3cND5G3w5KHeFJF09Zqgu8O9IcHELIcfXHp7/ZdodTo26fDLooFB/dsCPeiBlhwPfEQCPUeBP8O1+BaGjmoKT3/8Oz2HBWJgAyJByf+uNBHFU/MXVgI9wwC9EDN+6w8XMwMkg6AOHPgrkJX7zQeF9MTUJzoR/d979L9qPBWAhApj8BT0WB1/dul0iS2HnwOQFRL+ObLN6kUhV4gEOwrN7hmUCCkICvFqEalqMAJ77J4yxN+Z35RC/zPtVDboNkz+CA8aVbRqY3mcSzravwkNoGT4sAqS7M6JNZ3vsnXSHP8fJufWi5N1/wjP8c6YosRcfKzU1p6IE49ewACzOBvwRHOGMeomz/RvO9pOms105Z/BLYmAJ5JjNQ7Jxcp5NIQzHTZ0uJQge78++A9LUY1gA1s4TVgO95Q3I+8Vp10cPGNkLDXZV2kqGnYTCUH+La+ByhAM6WpQxrYuVC0ANuO/3l+aUzfi+Jz7DXTxcdXhiJQKYDToD9g5nah9W6pSxCwpNLIPzGz8dlgiipzzael3ON9Cg4jioViTOYAy0mZrImV1grFd5Jc1WRhC+X6aaWo4njHw7me1lPOHEKUPWhHpbjCAMhi7v1/m55Hh5AqOorK+4fklvmCjnsgSxUAEohyz0P+AA7LtbyhEyjc/4YrjooNhcPAoFwvqutssQxGIcsVJhCPQNAD7CEgbdhpTzH+EgvHR5wvj+ifDDj4sQROsCUOqGsVO7DkZPmMuP3b/jC1gjFHnCZCM4g+O2jXWrArjdCz7grD4yv5uEIFY128sitVcfQNmLPGg1bF+Gb6EltCIApeuj4BSMRlZOuWRHv19VnzkzusoZeyIEhZXZjnLKGCRqbbbKWKoaJP1NUpGeB99jIX/UFbhaEQzeGVUTBee8cLcNldRYAJMXGN6F4JNJ5UiJOj5+dFyFwTwYyRlraQVD7O9CUEihQkQznQBHKYPLoqUIaSMBJMsVPuUMLc5E5OSHZWffUjNlxPfJqHrh57IzWH1PiXbNsBq4hIM6q/vhdmri3+fBa8HgLP8O6vrIP3yIetpRzT9oH1VoJjEm5sdGNYvf4Xj78u491EAtAdgGn1RO9yo8Krq+0sCnHipQahLED4j5WE9N6qlI5XhJeKJ4Piv2iCsJYs8/NqkkCfxt9/J/J1ARlQWgdL4MvkPuBhgynLtj57VOY33f01SlJrn4BuFvF83D2CqsPHBSzBRKNUUoiIIAnU0IddRRJQEkA+h/1/V0mcG/fR68Qbtw7HDMlH8Ad78NF5UpuxeGjd0QyLjKYvtlEcJUMtitYphLC8CW5y0afGISzEeWZJ31q/EPnDQTyul1oxAqUtTyAngenOENv54/Vzj4zuT8ejhmbkGwCxndHbpUkmUlDDuX4S6UQGkBTPcCmTkh5UXnKnpla5/YCv9rXuVQDIgEF1Y2WKpfPTU5Q4NU5EMeODvBkn6LZ/RkDycnZK9FAZQa2yoCwMFM1Qjx/PjRU2uBlG3w1XXebhmKet8XMibyhDE8PQBKTxbG+VUqcqQcLymvq6ywJB4EFIbI3neBEJSa9ZCYpKuoLBtMuq4AukEMSG2L+NF59cGXFzL+9bCMgb2PpjJ50DhFWTHRovi+F3/NqSQSQhg+daqj594+rcQqQm81GGc11GX9A7weEzBmVdACyvJ9qxDQF0HV8hTavCdoCWoZBrgMK7Kk2bUVyxjH+I/8hbE681CiUi7jVYLvp+ztK2jxqLWMhhJMoWg8Pkdje+C6zhXMS3uZc8yCYZH9SAxqiIPG950lh2WMq2UlSC5etZXPaCcc/QKNl4TTzEk0uJ2r8LHruiSkIU+Ms1amQTOHvSl1bwV8vyiEkMaAyPOfv8epjMLHbZS0cGgBOFBZHpyyHdc1t3v+uySelKep5NKT8LavMA3Y0CumkkPqSwo4TPIF+r2LD7d7W++s1+OKw2t1ldPhXvABWkBjAdBA6uoDOz12qQq6Bm3DsX6eVJaMfn3cJLxrAwlCxuFTDDN8zH+uPHYKga6VkLknDDkcqDB6QzTLBxhZDzpolw4H7c+tfSbkJ/18GWPdFpK6VcjNYFcwLTXKN5BVRaU9XhuaCcCg+2XkPbbNfitNRfWQVieX+cw+rrBnlKLkwLbpnGAYpqbaT8nHZQNhqdN1qp2eSh+5vs3hMoQdcPXsNgmnNCpP13U/8eyOQ/Wkoeje/Dk18/+5OwMHMjRVQodiImhY6cun98FICur19EWgqhdiHn5zMRwSOAoBNCF0knu0zOooOgE/oH0P96uAgdp6NYSaqG0DkjRidjBpt6G1Pa4W0CKiykEriKSSbma+f0N6ugzHp3vC1XFGK+3fPwOnQ5fo9pxNGEz2/mN0Gon14H1o7eUgiU/VQ30jLGFfOx67lqKJKVHC3tZeqSt0hEoPfP7+lCAwD3HqGqDuVUSDPcreq3hnvYZWQRYdCLx9qInaAmCMPZs/TksLjVCz38iULPGkma0wVkXQbhv4iOruSDJxSP/oNcWaUi852xrZCgnSJQQUco5moqo5MLVNuf9w/hwX/BnURC0bkH6Z7ODQZjsLcICyqgBnv4tqGnMIeA0J7feryHBdTP8p1ZAyHFpt8wPe5wHxdvMeL1q5GO0dwpyKVOWK6Aia2iNp+Iyfcd8WhUwrwNh3EeqtANpQocGmflSATdP9NJBggcmvUMkbDH+X8Q9Qr58gE3uqO124ag4mf9pVBa4CPftl1+3C0ydbR4VAaqCeAESuqthO/UIvJ6w4Do3qioRlcNAwAhntVvGIlfdKnrgmBCa53XuNIvoO2c+w6PaUZmttwwHUQD0BaBvkcNB+OBoPtBP2bUGRf6CfwtlsdepcUEJgMqsWcGXZvFd1T1IO588V6PZxtm9eiwnVEgDqx53sGWFdAWisn8wfoyq4tvfLXmaO0a9whTSK6F+qFoeZk9K+VwF1+bV23Le2hWxbruqQqqPmCqhEC3PpPUfbbOydCathv30RnCK7maDjdUPesa0dGcxsn2Cf1UyOs8cOAUvZOBJKaCUa6oT+JZgwU0+DEYsZN6o2UiNkVNUBqhVcKXbd7mmf5xpUUSG8zLJtBWNdqIHFC6AJQs88IPombVf54WwD9/2xQwCc621bmeUurLcAgtg8WPlB7YENLLejsmOzHRTIewhNqMcrvAdbt7rOl5r6KolaAkAD9KNC4+wAWNiCydh6UuyY2iJbyrW18vAwpLbZe7B4ueo+MDQho0ddykt0r+6MNkj5NizL7jyA71ADrawALtmO9U19Zkj3Y2HmD2MGRr1qFJYfPjG3VYOfjfUwsDzJZXbN1Lktlkc+efaZiRTH3jeogZoCyA6qywBJxm61D9wGa2ONIQluZTeg0ctY8l17t5qXi5OAigigBqiIQHcWi+iyC3UdsXHmMHkkmAXZtk5uTY+XzPRr59Y4qN+0ttbQs8kfoAoOVxrShGSnDBWdZSFi7z3URM0VwLOOF3mYNqeI5YxTD6zdSt2hc8Xah9pxx5WjRY+avOKMWqFQt/IjCnK7SV4i+ICO4ldjaX7N2U+olZJM86OT+XM4s5+a0oFpWcdNubamfsVh90t8BgZk6lUTOHO09OgC5gNdkxcq1QmR08YfvHoOfFsmeY+Bqb828ti1VoAybLpHK803aQxcWdvmY+0YQLOqFmME05LNSvpHmhlBLkiXdtYj44yfdzr7h4N/AgscfEJtFoQ3p1l9+/YfPVmTxtrNbUUusWNVQybdrrJZf9nVnBICRkr1MpPSoJonlYhvp4KjPg1lYpg5BPmsbFtwxtpVdYTG27ess9qwCjqU0HGmIXFVdq/CA6rgSARRJq5DW6jEKyryanNTSe2yFKO+tpRomNval7DhqYvuchHzUxpR3YS7ZcsH1T4EyZ4IJrvk1wiM9+HsvEl2Zi5u31qjuiDdCLrK0HMGE21I54u5dtRkuGm7UOfy7lXZe5l9RluPFFgUGnnCJi5uW/omZ8hWNqKSKblyEbnvppnhq5xxlUlyv6g8ZZVoFoqoUKKhVJM2QELac8MQq8dEZpY98vBPNgOranYMachMeYrDOK8KjQRgoo2ehImtPaqo3CqY7G0d2/qWUuiVBlS59snKima5YEOlmipPiYIbJYgWimrbQiMbQEj0dXRKD8pDtXFe9IBT1NUUNZwPR1Q2sKjqzra/uB8jbNvN/gBiPnx4/0xRgWHr+SgrhcKZ6Kn8gWQ9j7ObRTxZsbEAqiJ9ToQeT7F6sPoOxBlKCcG+16sW6j4PwoWlJ2TIFhicIHc9pkG3U0qSVpPb6fo5dm3OqAouRa3Eu7NPWAViRVU1A4serCW5bqvzQfSV01VgXO93yaCfooRfUxisQRW0o8/VIP1VjU/a3RRsiLaqlCmqh/dV1MPsxxywrz568TsqWY927L5B9iGxI3TQrhfxWIWVCYBQx4N163V2If27t+vseOlYrQAse3GhUAhkmLeQeUmjz7HMJ982xUoFQHDtSi+K5RRRTSWIFf5EVRmsXACERkIoQzXX4PfCbFgLARBs2arSz5ko2JA9j7YfN9AEa1OYlWSr8nX9GWbiur5gQ/Y8KCG/LuGItaqMy/N9pIIRL5z9mT50zm9Jtnggt2ENsDYqSEdS6VbvdwNyfc1+Lywpn+nRLzqVfaDSBhtssMEGG2ywwQYbbLBB2/g/1Hk/5b0pbhgAAAAASUVORK5CYII\u003d"
   },
-  "description": "This template adds the Fingerprint Pro JS agent to your website, allowing you to identify visitors with 99.5% percent accuracy. Visit https://fingerprint.com/ for more information and get your public API key.",
+  "description": "This template adds the Fingerprint JS agent to your website, allowing you to identify visitors with industry-leading accuracy. Visit https://fingerprint.com/ for more information and get your public API key.",
   "containerContexts": [
     "WEB"
   ]
@@ -40,11 +32,11 @@ ___TEMPLATE_PARAMETERS___
     "selectItems": [
       {
         "value": "default",
-        "displayValue": "Load and identify"
+        "displayValue": "Start and identify"
       },
       {
-        "value": "load",
-        "displayValue": "Load"
+        "value": "start",
+        "displayValue": "Start"
       },
       {
         "value": "get",
@@ -72,7 +64,7 @@ ___TEMPLATE_PARAMETERS___
       },
       {
         "paramName": "tagType",
-        "paramValue": "load",
+        "paramValue": "start",
         "type": "EQUALS"
       }
     ]
@@ -106,7 +98,7 @@ ___TEMPLATE_PARAMETERS___
       },
       {
         "paramName": "tagType",
-        "paramValue": "load",
+        "paramValue": "start",
         "type": "EQUALS"
       }
     ]
@@ -124,18 +116,24 @@ ___TEMPLATE_PARAMETERS___
         "groupStyle": "NO_ZIPPY",
         "subParams": [
           {
-            "type": "TEXT",
-            "name": "scriptUrlPattern",
-            "displayName": "Script Url Pattern",
-            "simpleValueType": true,
-            "help": "Pattern of the JS agent script URL."
-          },
-          {
-            "type": "TEXT",
-            "name": "endpoint",
-            "displayName": "Endpoint",
-            "simpleValueType": true,
-            "help": "Server API URL. Should be only used with Custom subdomain setup or Proxy integration."
+            "type": "SIMPLE_TABLE",
+            "name": "endpoints",
+            "displayName": "endpoints",
+            "simpleTableColumns": [
+              {
+                "defaultValue": "",
+                "displayName": "",
+                "name": "endpoint",
+                "type": "TEXT",
+                "isUnique": true,
+                "valueValidators": [
+                  {
+                    "type": "NON_EMPTY"
+                  }
+                ]
+              }
+            ],
+            "help": "API endpoints used by the JS Agent. If you are using a custom subdomain or a proxy integration, add a row with the endpoint URL for the integration. Leave the table empty to use the default configuration."
           }
         ],
         "enablingConditions": [
@@ -146,7 +144,7 @@ ___TEMPLATE_PARAMETERS___
           },
           {
             "paramName": "tagType",
-            "paramValue": "load",
+            "paramValue": "start",
             "type": "EQUALS"
           }
         ]
@@ -172,18 +170,12 @@ ___TEMPLATE_PARAMETERS___
             "help": "A way of linking current identification event with a custom identifier"
           },
           {
-            "type": "CHECKBOX",
-            "name": "extendedResult",
-            "checkboxText": "Extended result",
-            "simpleValueType": true
-          },
-          {
             "type": "TEXT",
             "name": "resultCustomName",
             "displayName": "Result custom name",
             "simpleValueType": true,
             "help": "You can change the name of the result variable emitted to the dataLayer",
-            "defaultValue": "FingerprintJSProResult",
+            "defaultValue": "FingerprintResult",
             "valueValidators": [
               {
                 "type": "NON_EMPTY"
@@ -211,7 +203,6 @@ ___TEMPLATE_PARAMETERS___
 
 ___SANDBOXED_JS_FOR_WEB_TEMPLATE___
 
-// Enter your template code here.
 const log = require('logToConsole');
 const injectScript = require('injectScript');
 const queryPermission = require('queryPermission');
@@ -226,21 +217,16 @@ log('data =', data);
 
 const tagType = data.tagType;
 
-const loadOptions = {
+const startOptions = {
   apiKey: data.apiKey,
-  integrationInfo: 'fingerprintjs-pro-gtm-template/1.0.0',
 };
 
 if (data.region) {
-  loadOptions.region = data.region;
+  startOptions.region = data.region;
 }
 
-if (data.endpoint) {
-  loadOptions.endpoint = data.endpoint;
-}
-
-if (data.scriptUrlPattern) {
-  loadOptions.scriptUrlPattern = data.scriptUrlPattern;
+if (data.endpoints) {
+  startOptions.endpoints = data.endpoints.map(param => param.endpoint);
 }
 
 const getOptions = {};
@@ -253,66 +239,65 @@ if (data.linkedId) {
   getOptions.linkedId = data.linkedId;
 }
 
-if (data.extendedResult) {
-  getOptions.extendedResult = true;
-}
-
-log('loadOptions =', loadOptions);
+log('startOptions =', startOptions);
 log('getOptions=', getOptions);
 
 const dataLayerPush = createQueue('dataLayer');
 
 let getStartTime;
-const onFpJsGet = (result) => {
+const onFpGet = (result) => {
   log('result', result);
   const getFinishTime = getTimestampMillis();
-  const event = {event: 'FingerprintJSPro.identified'};
+  const event = {event: 'Fingerprint.identified'};
   result.timeToIdentifyMs = getFinishTime - getStartTime;
   event[data.resultCustomName] = result;
   dataLayerPush(event);
   data.gtmOnSuccess();
 };
 
+const onFpGetFailure = (reason) => {
+  log('Fingerprint: Identification failed', reason);
+  data.gtmOnFailure();
+};
+
 const doIdentification = () => {
   log('doIdentification');
   getStartTime = getTimestampMillis();
-  if (queryPermission('access_globals', 'execute', 'FingerprintjsProGTM.get')) {
-    callInWindow('FingerprintjsProGTM.get', getOptions, onFpJsGet);
+  if (queryPermission('access_globals', 'execute', 'FingerprintGTM.get')) {
+    callInWindow('FingerprintGTM.get', getOptions, onFpGet, onFpGetFailure);
   } else {
-    log('FingerprintJS: Identification failed due to permissions mismatch.');
+    log('Fingerprint: Identification failed due to permissions mismatch.');
     data.gtmOnFailure();
   }
 };
 
 const onSuccess = () => {
-  log('FingerprintJS: Script loaded successfully.');
+  log('Fingerprint: Script load successfully.');
 
-  const onFpJsLoad = () => {
-    const event = {event: 'FingerprintJSPro.loaded'};
-    dataLayerPush(event);
-    log('loaded');
-    if (tagType === 'default') {
-      doIdentification();
-    } else {
-      data.gtmOnSuccess();
-    }
-  };
+  callInWindow('FingerprintGTM.start', startOptions);
 
-  callInWindow('FingerprintjsProGTM.load', loadOptions, onFpJsLoad);
+  const event = {event: 'Fingerprint.started'};
+  dataLayerPush(event);
+  log('started');
+  if (tagType === 'default') {
+    doIdentification();
+  } else {
+    data.gtmOnSuccess();
+  }
 };
 
 // If the script fails to load, log a message and signal failure
 const onFailure = () => {
-  log('FingerprintJS: Script load failed.');
+  log('Fingerprint: Script load failed.');
   data.gtmOnFailure();
 };
 
-if (tagType === 'default' || tagType === 'load') {
-  if (queryPermission('inject_script', url) && queryPermission('access_globals', 'execute', 'FingerprintjsProGTM.load')) {
+if (tagType === 'default' || tagType === 'start') {
+  if (queryPermission('inject_script', url) && queryPermission('access_globals', 'execute', 'FingerprintGTM.start')) {
     log('try to load');
     injectScript(url, onSuccess, onFailure);
   } else {
-    log('FingerprintJS: Script load failed due to permissions mismatch.');
+    log('Fingerprint: Script load failed due to permissions mismatch.');
     data.gtmOnFailure();
   }
 } else {
@@ -405,7 +390,7 @@ ___WEB_PERMISSIONS___
                 "mapValue": [
                   {
                     "type": 1,
-                    "string": "FingerprintjsProGTM.load"
+                    "string": "FingerprintGTM.start"
                   },
                   {
                     "type": 8,
@@ -483,7 +468,7 @@ ___WEB_PERMISSIONS___
                 "mapValue": [
                   {
                     "type": 1,
-                    "string": "FingerprintjsProGTM.get"
+                    "string": "FingerprintGTM.get"
                   },
                   {
                     "type": 8,
@@ -527,9 +512,7 @@ scenarios:
     });
 
     mock('callInWindow', function(fname, options, callback) {
-      if (fname === 'FingerprintjsProGTM.load') {
-        callback();
-      } else if(fname === 'FingerprintjsProGTM.get') {
+      if(fname === 'FingerprintGTM.get') {
         callback({visitorId: 'qwerty'});
       }
     });
@@ -541,10 +524,10 @@ scenarios:
     assertApi('createQueue').wasCalled();
     // Verify that the tag finished successfully.
     assertApi('gtmOnSuccess').wasCalled();
-- name: check loading load tag
+- name: check loading start tag
   code: |-
     const mockData = {
-      tagType: 'load',
+      tagType: 'start',
       apiKey: 'aspodkasodk',
     };
 
@@ -553,10 +536,8 @@ scenarios:
     });
 
     mock('callInWindow', function(fname, options, callback) {
-      if (fname === 'FingerprintjsProGTM.load') {
-        callback();
-      } else if(fname === 'FingerprintjsProGTM.get') {
-        fail('Tag called get funciton');
+      if(fname === 'FingerprintGTM.get') {
+        fail('Tag called get function');
       }
     });
 
@@ -579,9 +560,9 @@ scenarios:
     });
 
     mock('callInWindow', function(fname, options, callback) {
-      if (fname === 'FingerprintjsProGTM.load') {
-        fail('Tag called load funciton');
-      } else if(fname === 'FingerprintjsProGTM.get') {
+      if (fname === 'FingerprintGTM.start') {
+        fail('Tag called start function');
+      } else if(fname === 'FingerprintGTM.get') {
         callback({visitorId: 'qwerty'});
       }
     });
@@ -593,16 +574,15 @@ scenarios:
     assertApi('createQueue').wasCalled();
     // Verify that the tag finished successfully.
     assertApi('gtmOnSuccess').wasCalled();
-- name: check loadOptions ang getOptions with minimum params
+- name: check startOptions ang getOptions with minimum params
   code: |-
     const mockData = {
       tagType: 'default',
       apiKey: 'aspodkasodk',
     };
 
-    const expectedLoadOptions = {
+    const expectedStartOptions = {
       apiKey: 'aspodkasodk',
-      integrationInfo: 'fingerprintjs-pro-gtm-template/1.0.0',
     };
 
     mock('injectScript', function(url, onSuccess, onFail) {
@@ -610,10 +590,9 @@ scenarios:
     });
 
     mock('callInWindow', function(fname, options, callback) {
-      if (fname === 'FingerprintjsProGTM.load') {
-        assertThat(options).isEqualTo(expectedLoadOptions);
-        callback();
-      } else if(fname === 'FingerprintjsProGTM.get') {
+      if (fname === 'FingerprintGTM.start') {
+        assertThat(options).isEqualTo(expectedStartOptions);
+      } else if(fname === 'FingerprintGTM.get') {
         assertThat(options).isEqualTo({});
         callback({visitorId: 'qwerty'});
       }
@@ -623,31 +602,26 @@ scenarios:
     runCode(mockData);
 
     assertApi('gtmOnSuccess').wasCalled();
-- name: check loadOptions ang getOptions with maximum params
+- name: check startOptions ang getOptions with maximum params
   code: |-
     const mockData = {
       tagType: 'default',
       apiKey: 'aspodkasodk',
       region: 'eu',
-      scriptUrlPattern: 'https://domain.some/v<version>/<apiKey>/loader_v<loaderVersion>.js',
-      endpoint: 'https://end.point/',
+      endpoints: [{ endpoint: 'https://end1.point/' }, { endpoint: 'https://end2.point' }],
       tag: 'myTag',
       linkedId: 'some-id',
-      extendedResult: true,
     };
 
-    const expectedLoadOptions = {
+    const expectedStartOptions = {
       apiKey: 'aspodkasodk',
-      integrationInfo: 'fingerprintjs-pro-gtm-template/1.0.0',
       region: 'eu',
-      endpoint: 'https://end.point/',
-      scriptUrlPattern: 'https://domain.some/v<version>/<apiKey>/loader_v<loaderVersion>.js',
+      endpoints: ['https://end1.point/', 'https://end2.point'],
     };
 
     const expectedGetOptions = {
       tag: 'myTag',
       linkedId: 'some-id',
-      extendedResult: true,
     };
 
 
@@ -656,10 +630,9 @@ scenarios:
     });
 
     mock('callInWindow', function(fname, options, callback) {
-      if (fname === 'FingerprintjsProGTM.load') {
-        assertThat(options).isEqualTo(expectedLoadOptions);
-        callback();
-      } else if(fname === 'FingerprintjsProGTM.get') {
+      if (fname === 'FingerprintGTM.start') {
+        assertThat(options).isEqualTo(expectedStartOptions);
+      } else if(fname === 'FingerprintGTM.get') {
         assertThat(options).isEqualTo(expectedGetOptions);
         callback({visitorId: 'qwerty'});
       }
@@ -669,12 +642,11 @@ scenarios:
     runCode(mockData);
 
     assertApi('gtmOnSuccess').wasCalled();
-- name: check visitorIdCustomName field works
+- name: check resultCustomName field works
   code: |-
     const mockData = {
       tagType: 'get',
       apiKey: 'aspodkasodk',
-      visitorIdCustomName: 'fingerprintJsProVisitorId',
       resultCustomName: 'result'
     };
 
@@ -683,18 +655,18 @@ scenarios:
     });
 
     mock('callInWindow', function(fname, options, callback) {
-      if (fname === 'FingerprintjsProGTM.load') {
-        callback();
-      } else if(fname === 'FingerprintjsProGTM.get') {
+      if(fname === 'FingerprintGTM.get') {
         callback({visitorId: 'qwerty'});
       }
     });
 
     mock('createQueue', function(name) {
       return function(params) {
+        const timeToIdentifyMs = params.result ? params.result.timeToIdentifyMs : undefined;
+        assertThat(timeToIdentifyMs).isGreaterThanOrEqualTo(0);
         assertThat(params).isEqualTo({
-          event: 'FingerprintJSPro.identified',
-          result: {visitorId: 'qwerty', timeToIdentifyMs: 0},
+          event: 'Fingerprint.identified',
+          result: {visitorId: 'qwerty', timeToIdentifyMs: timeToIdentifyMs },
         });
       };
     });
@@ -704,8 +676,27 @@ scenarios:
 
     // Verify that the tag finished successfully.
     assertApi('gtmOnSuccess').wasCalled();
+- name: check get failure handling
+  code: |-
+    const mockData = {
+      tagType: 'get',
+      apiKey: 'aspodkasodk',
+    };
 
+    mock('injectScript', function(url, onSuccess, onFail) {
+      onSuccess();
+    });
+
+    mock('callInWindow', function(fname, options, onFulfilled, onRejected) {
+      if(fname === 'FingerprintGTM.get') {
+        onRejected({ name: 'Error', message: 'failed' });
+      }
+    });
+
+    // Call runCode to run the template's code.
+    runCode(mockData);
+
+    // Verify that tag reported failure
+    assertApi('gtmOnFailure').wasCalled();
 
 ___NOTES___
-
-Created on 30.03.2022, 20:54:30

--- a/template.tpl
+++ b/template.tpl
@@ -140,9 +140,9 @@ ___TEMPLATE_PARAMETERS___
                   {
                     "type": "REGEX",
                     "args": [
-                      "^https:\\/\\/[^\\s\\$.?#]\\.[^\\s]*$"
+                      "^https:\\/\\/[^\\s\\$.?#]+\\.[^\\s]*$"
                     ],
-                    "errorMessage": "Enter a valid https:// URL"
+                    "errorMessage": "Enter a valid https:// URL. It must include a TLD suffix."
                   }
                 ]
               }

--- a/template.tpl
+++ b/template.tpl
@@ -136,6 +136,13 @@ ___TEMPLATE_PARAMETERS___
                 "valueValidators": [
                   {
                     "type": "NON_EMPTY"
+                  },
+                  {
+                    "type": "REGEX",
+                    "args": [
+                      "^https:\\/\\/[^\\s\\$.?#]\\.[^\\s]*$"
+                    ],
+                    "errorMessage": "Enter a valid https:// URL"
                   }
                 ]
               }


### PR DESCRIPTION
## Changes
- Update the default result name to be `FingerprintResult`. This aligns with updates to terminology to remove "JS" suffix from Fingerprint and "Pro" terminology throughout. This also allows the v3 tag to coexist with v4 tag with no updates to the v3 tag.
- Rename `FingerprintJSPro.identified` and `FingerprintJSPro.loaded` events to be `Fingerprint.identified` and `Fingerprint.started` to align with other renames. This also allows the v3 tag to coexist with the v4 tag.
- Update the references to the global variable for the adapter to use `FingerprintGTM` in place of `FingerprintjsProGTM`. The v4 adapter will use this name for its iife global variable when the CDN is updated.
- Update invocation of `FingerprintGTM.get` to accept a function that will be invoked when the get fails. This allows the tag to indicate failure when the get fails.
- Add test for `FingerprintGTM.get` failure.
- No longer include `fingerprintjs-pro-gtm-template/1.0.0` `integrationInfo`. The GTM adapter will set the integration info to `fingerprintjs-pro-gtm/VERSION`. 
- Replace mentions `load` (i.e., the JS agent v3 function) with `start`, the JS agent v4 function. This includes updating the tag types use the "start" terminology.
- Replace `scriptUrlPattern` and `endpoint` optional parameters with `endpoints` table.
- Remove `extendedResult` parameter as it is no longer needed.
- Update README.md to account for renamed parameters and labels.
- Fix flake in custom result test by checking that `timeToIdentifyMs` is set to a value greater than or equal to 0

## Test setup
- [x] Created an `iife` version of the GTM adapter, built locally with: `pnpm dlx esbuild dist/fpjs-pro-gtm.esm.js --bundle --minify --target=es2020 --format=iife --global-name=FingerprintGTM --outfile=./gtm-adapter.iife.js` and deployed to my personal sandbox.
- [x] Deployed the template from this PR with one modification that it is using the GTM script from my personal sandbox, rather than the CDN

## Test cases
- [x] Tag using `Start and identify` tag type
- [x] Tag using EU region
- [x] Tag using `Start` tag type combined with a tag using the `Identify` tag type, triggered from a custom event published by the JS app on the page.
- [x] Tag using a custom result name, tag, linked ID, and multiple endpoints, the first of which intentionally fails to confirm that multiple endpoints are being passed correctly to the JS agent.
- [x] Downstream tag that logs the result mapped from data layer variables

In all test cases, the tag was triggered based on the `Page Path`, targeting a test HTML page that validates the scenario.
