### PR TITLE
chore: prepare for repo and package rename

### DIFF
--- a/.changeset/adapter-js-agent-v4.md
+++ b/.changeset/adapter-js-agent-v4.md
@@ -1,5 +1,5 @@
 ---
-'@fingerprintjs/fingerprintjs-pro-gtm': major
+'@fingerprint/gtm-adapter': major
 ---
 
 Switch to JS Agent v4 (`@fingerprint/agent`) in the GTM adapter. This is a breaking change.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": [
     "@fingerprintjs/changesets-changelog-format",
     {
-      "repo": "fingerprintjs/fingerprintjs-pro-gtm"
+      "repo": "fingerprintjs/gtm-integration"
     }
   ],
   "commit": false,

--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -2,7 +2,7 @@
   "mode": "pre",
   "tag": "test",
   "initialVersions": {
-    "@fingerprintjs/fingerprintjs-pro-gtm": "1.1.0"
+    "@fingerprint/gtm-adapter": "1.1.0"
   },
   "changesets": []
 }

--- a/.changeset/template-js-agent-v4.md
+++ b/.changeset/template-js-agent-v4.md
@@ -1,5 +1,5 @@
 ---
-'@fingerprintjs/fingerprintjs-pro-gtm': major
+'@fingerprint/gtm-adapter': major
 ---
 
 Update GTM template to support JS agent v4. This is a breaking change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,81 +1,81 @@
 # Fingerprint Google Tag Manager Template
 
-## [1.1.0](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/compare/v1.0.0...v1.1.0) (2024-03-28)
+## [1.1.0](https://github.com/fingerprintjs/gtm-integration/compare/v1.0.0...v1.1.0) (2024-03-28)
 
 
 ### Features
 
-* add identification request timing ([2c97d3e](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/2c97d3e4caf95423a961554caa25ed81a1ad9c39))
-* create tag version with 3 roles: load, identify and load + identify ([4ae0f7b](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/4ae0f7b90bbbf25f7c93aa809a76e5e153b4b160))
+* add identification request timing ([2c97d3e](https://github.com/fingerprintjs/gtm-integration/commit/2c97d3e4caf95423a961554caa25ed81a1ad9c39))
+* create tag version with 3 roles: load, identify and load + identify ([4ae0f7b](https://github.com/fingerprintjs/gtm-integration/commit/4ae0f7b90bbbf25f7c93aa809a76e5e153b4b160))
 
 
 ### Bug Fixes
 
-* show tag settings depends on tag type ([b77ddba](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/b77ddba7e55cc43aedd99adbc6b044159ea29bcb))
+* show tag settings depends on tag type ([b77ddba](https://github.com/fingerprintjs/gtm-integration/commit/b77ddba7e55cc43aedd99adbc6b044159ea29bcb))
 
 
 ### Documentation
 
-* **README:** add description to the `Tag type` template field ([dc4b3b2](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/dc4b3b24cfc422fe8077b6023f9592782ed0dba3))
-* **README:** remove beta warning ([c3c13dc](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/c3c13dc401f45d58b92ca0f6755ef492f33ba9d2))
-* **README:** update readme ([7e46ee5](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/7e46ee5c68acf03f9cc4cf054cc26775d39ecc10))
+* **README:** add description to the `Tag type` template field ([dc4b3b2](https://github.com/fingerprintjs/gtm-integration/commit/dc4b3b24cfc422fe8077b6023f9592782ed0dba3))
+* **README:** remove beta warning ([c3c13dc](https://github.com/fingerprintjs/gtm-integration/commit/c3c13dc401f45d58b92ca0f6755ef492f33ba9d2))
+* **README:** update readme ([7e46ee5](https://github.com/fingerprintjs/gtm-integration/commit/7e46ee5c68acf03f9cc4cf054cc26775d39ecc10))
 
 ## 1.0.0 (2023-04-07)
 
 ##### Chores
 
 * **deps:**
-  *  bump json5 from 2.2.0 to 2.2.3 ([67fc05a9](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/67fc05a9858b57fc19c70bebd58e9a97337e7b62))
-  *  bump rollup-plugin-license ([27dae632](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/27dae63247d86cb0854354a7261527ae4db4503a))
-  *  bump minimist from 1.2.5 to 1.2.6 ([7472efba](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/7472efbafe4386187b59fd06dc4c9de283ac513e))
-*  add production environment for publish task ([09a15c0a](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/09a15c0a0140693179f402bbaeb94a3683aaf317))
-*  update documentation link ([58cfb7ee](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/58cfb7ee8ce18773e4aa5af141e59d5d966c2f67))
+  *  bump json5 from 2.2.0 to 2.2.3 ([67fc05a9](https://github.com/fingerprintjs/gtm-integration/commit/67fc05a9858b57fc19c70bebd58e9a97337e7b62))
+  *  bump rollup-plugin-license ([27dae632](https://github.com/fingerprintjs/gtm-integration/commit/27dae63247d86cb0854354a7261527ae4db4503a))
+  *  bump minimist from 1.2.5 to 1.2.6 ([7472efba](https://github.com/fingerprintjs/gtm-integration/commit/7472efbafe4386187b59fd06dc4c9de283ac513e))
+*  add production environment for publish task ([09a15c0a](https://github.com/fingerprintjs/gtm-integration/commit/09a15c0a0140693179f402bbaeb94a3683aaf317))
+*  update documentation link ([58cfb7ee](https://github.com/fingerprintjs/gtm-integration/commit/58cfb7ee8ce18773e4aa5af141e59d5d966c2f67))
 
 ##### Documentation Changes
 
-*  rename the custom subdomain feature name ([89038318](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/8903831891281cd93f753d003965803b508e7336))
-*  update Fingerprint logo ([d0fa722c](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/d0fa722c2f55bcaf59c4aaefe098544010ed92ac))
-*  replace fingerprintjs.com to fingerprint.com ([a7850334](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/a785033409d59fcc61b00af3cb556bf775bb28e2))
-*  remove whitespace ([ada10547](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/ada1054748f77a776c6f6f518a59471b3ee95704))
-*  Split contributing file into 2 products ([e5c21832](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/e5c21832c09a76e028c7b7b013d22088ccb4f9f1))
-*  Add CODEOWNERS ([d5a05a0b](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/d5a05a0b6bfbe60986c82817d35c0f00cb0228e0))
-*  Add contributing rules ([e2516fbb](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/e2516fbb737976707cc941913610d1076284335a))
-*  fix markdown for headers in readme ([9de5a154](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/9de5a154c8a793d4035cd305d565388c9739a305))
-*  update readme ([35382e8d](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/35382e8da075ac869a63faa95f5de6f41e349a6c))
-*  change license to Apache 2.0 ([e8bdac2d](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/e8bdac2d91e890e934ce9c6bd23b2feed91a54fe))
-*  update description ([44cf8079](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/44cf8079f9335b1105c31341628fc78aaa312a0a))
-* **README:**  remove GTM Gallery mention ([cc08755f](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/cc08755fbbaea55a6707a388b83db56cef4c745d))
+*  rename the custom subdomain feature name ([89038318](https://github.com/fingerprintjs/gtm-integration/commit/8903831891281cd93f753d003965803b508e7336))
+*  update Fingerprint logo ([d0fa722c](https://github.com/fingerprintjs/gtm-integration/commit/d0fa722c2f55bcaf59c4aaefe098544010ed92ac))
+*  replace fingerprintjs.com to fingerprint.com ([a7850334](https://github.com/fingerprintjs/gtm-integration/commit/a785033409d59fcc61b00af3cb556bf775bb28e2))
+*  remove whitespace ([ada10547](https://github.com/fingerprintjs/gtm-integration/commit/ada1054748f77a776c6f6f518a59471b3ee95704))
+*  Split contributing file into 2 products ([e5c21832](https://github.com/fingerprintjs/gtm-integration/commit/e5c21832c09a76e028c7b7b013d22088ccb4f9f1))
+*  Add CODEOWNERS ([d5a05a0b](https://github.com/fingerprintjs/gtm-integration/commit/d5a05a0b6bfbe60986c82817d35c0f00cb0228e0))
+*  Add contributing rules ([e2516fbb](https://github.com/fingerprintjs/gtm-integration/commit/e2516fbb737976707cc941913610d1076284335a))
+*  fix markdown for headers in readme ([9de5a154](https://github.com/fingerprintjs/gtm-integration/commit/9de5a154c8a793d4035cd305d565388c9739a305))
+*  update readme ([35382e8d](https://github.com/fingerprintjs/gtm-integration/commit/35382e8da075ac869a63faa95f5de6f41e349a6c))
+*  change license to Apache 2.0 ([e8bdac2d](https://github.com/fingerprintjs/gtm-integration/commit/e8bdac2d91e890e934ce9c6bd23b2feed91a54fe))
+*  update description ([44cf8079](https://github.com/fingerprintjs/gtm-integration/commit/44cf8079f9335b1105c31341628fc78aaa312a0a))
+* **README:**  remove GTM Gallery mention ([cc08755f](https://github.com/fingerprintjs/gtm-integration/commit/cc08755fbbaea55a6707a388b83db56cef4c745d))
 
 ##### New Features
 
-*  separate `load` and `get` logic ([188d2e89](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/188d2e89d880c9efd5e1171d6adef13b901054a0))
+*  separate `load` and `get` logic ([188d2e89](https://github.com/fingerprintjs/gtm-integration/commit/188d2e89d880c9efd5e1171d6adef13b901054a0))
 
 ## 0.3.0 (2022-03-29)
 
 ##### Chores
 
-*  remove iife format ([090daddc](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/090daddcd007881577ce4bbaf7c26aa8388f7c91))
-*  add typecheck to build action ([c703b234](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/c703b234df81725369de5ee72514bea84a864c79))
-*  allow rollup to remove unused code from deps ([ca071f39](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/ca071f3949c9908b231b7b9785b82dde69c7e8ed))
-*  generate only esm module ([94981e1c](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/94981e1cb922a0ff2ea9308e75c1c74112276415))
-*  move rollup resolve to devDependencies section ([7458c77a](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/7458c77a9218b41d7da4539d130ba793d964919a))
+*  remove iife format ([090daddc](https://github.com/fingerprintjs/gtm-integration/commit/090daddcd007881577ce4bbaf7c26aa8388f7c91))
+*  add typecheck to build action ([c703b234](https://github.com/fingerprintjs/gtm-integration/commit/c703b234df81725369de5ee72514bea84a864c79))
+*  allow rollup to remove unused code from deps ([ca071f39](https://github.com/fingerprintjs/gtm-integration/commit/ca071f3949c9908b231b7b9785b82dde69c7e8ed))
+*  generate only esm module ([94981e1c](https://github.com/fingerprintjs/gtm-integration/commit/94981e1cb922a0ff2ea9308e75c1c74112276415))
+*  move rollup resolve to devDependencies section ([7458c77a](https://github.com/fingerprintjs/gtm-integration/commit/7458c77a9218b41d7da4539d130ba793d964919a))
 
 ##### Documentation Changes
 
-*  update README.md ([a6931ecf](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/a6931ecfb753c4a48e3ceee9d99526397065a048))
-*  add ci badge, add beta notice ([b5f0aceb](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/b5f0acebab7739b45b8f166734971a94022d8c56))
+*  update README.md ([a6931ecf](https://github.com/fingerprintjs/gtm-integration/commit/a6931ecfb753c4a48e3ceee9d99526397065a048))
+*  add ci badge, add beta notice ([b5f0aceb](https://github.com/fingerprintjs/gtm-integration/commit/b5f0acebab7739b45b8f166734971a94022d8c56))
 
 ##### New Features
 
-*  add integrationInfo to loadOptions ([aff41286](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/aff412863fa4f6d947e4ccc6fedc588ca64733f9))
-*  use separate options for load and get ([7c8eaa0c](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/7c8eaa0c2fb3119e552022f0347e15f7dccf6000))
-*  use new fpjs-pro agent v3.6.0 ([3bb739ef](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/3bb739efce45fdececaac7f4d002296c25673a99))
-*  support endpoint, tag and linkedIt options ([b264b849](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/b264b849dc972b41a727b1ed5f6ebb5d05254e8a))
+*  add integrationInfo to loadOptions ([aff41286](https://github.com/fingerprintjs/gtm-integration/commit/aff412863fa4f6d947e4ccc6fedc588ca64733f9))
+*  use separate options for load and get ([7c8eaa0c](https://github.com/fingerprintjs/gtm-integration/commit/7c8eaa0c2fb3119e552022f0347e15f7dccf6000))
+*  use new fpjs-pro agent v3.6.0 ([3bb739ef](https://github.com/fingerprintjs/gtm-integration/commit/3bb739efce45fdececaac7f4d002296c25673a99))
+*  support endpoint, tag and linkedIt options ([b264b849](https://github.com/fingerprintjs/gtm-integration/commit/b264b849dc972b41a727b1ed5f6ebb5d05254e8a))
 
 ##### Bug Fixes
 
-*  pick function, tests ([0b22e61a](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/0b22e61a9d75c91edd40c19aaa35fb4fbeb72f9b))
-*  remove unnecessary esm build ([1723ace3](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/1723ace303290f4dabc1218f0e3ded1172d53826))
+*  pick function, tests ([0b22e61a](https://github.com/fingerprintjs/gtm-integration/commit/0b22e61a9d75c91edd40c19aaa35fb4fbeb72f9b))
+*  remove unnecessary esm build ([1723ace3](https://github.com/fingerprintjs/gtm-integration/commit/1723ace303290f4dabc1218f0e3ded1172d53826))
 
 ### 0.2.0 (2022-03-22)
 

--- a/README.md
+++ b/README.md
@@ -13,27 +13,27 @@
   </a>
 </p>
 
-# Fingerprint Pro Google Tag Manager template
+# Fingerprint Google Tag Manager template
 
-This repository contains a Google Tag Manager template you can use to add [Fingerprint Pro](https://fingerprint.com/) to your website.  
+This repository contains a Google Tag Manager template you can use to add [Fingerprint](https://fingerprint.com/) to your website.  
 
 For step-by-step instructions on using this integration, see the full [Google Tag Manager guide](https://dev.fingerprint.com/docs/fingerprintjs-pro-google-tag-manager) in the Fingerprint documentation.
 
 
 ## Usage
 
-1. [Sign up](https://dashboard.fingerprint.com/signup) for a Fingerprint Pro account if you haven't already.
+1. [Sign up](https://dashboard.fingerprint.com/signup) for a Fingerprint account if you haven't already.
 2. Import this `template.tpl` from [latest release](https://github.com/fingerprintjs/gtm-integration/releases) into your Google Tag Manager workspace.
-3. Add a Fingerprint Pro tag to your website. You will need your public API key and workspace region.
-4. Use the `FingerprintResult` or your own *Custom result name* to access the Fingerprint Pro result in GTM's `dataLayer`.
+3. Add a Fingerprint tag to your website. You will need your public API key and workspace region.
+4. Use the `FingerprintResult` or your own *Custom result name* to access the Fingerprint result in GTM's `dataLayer`.
 5. Use the `Fingerprint.started` and `Fingerprint.identified` event names to create custom events and trigger actions after the JS agent is loaded or the visitor is identified.
 
 ## Template Fields
 
-For more information and the full API reference, see [Fingerprint Pro JS Agent](https://dev.fingerprint.com/docs/js-agent) in our documentation.
+For more information and the full API reference, see [Fingerprint JS Agent](https://dev.fingerprint.com/docs/js-agent) in our documentation.
 
 `Tag type` – The way you want to use the tag. There are 3 options:
-  - `Start and identify` – the default behavior. Start the JS agent and identify the browser immediately. If you want to start the JS agent first and identify the browser later based on some event, use two separate `Start` and `Identify` Fingerprint Pro tags.
+  - `Start and identify` – the default behavior. Start the JS agent and identify the browser immediately. If you want to start the JS agent first and identify the browser later based on some event, use two separate `Start` and `Identify` Fingerprint tags.
   - `Start` – only load the JS Agent.
   - `Identify` – identify the browser. The JS Agent must be started before. You can collect additional metadata data first and then trigger this tag with the metadata inside `linkedId` or `tag`.
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
   </a>
 </p>
 <p align="center">
-  <a href="https://github.com/fingerprintjs/fingerprintjs-pro-gtm/actions/workflows/build.yml">
-    <img src="https://github.com/fingerprintjs/fingerprintjs-pro-gtm/actions/workflows/build.yml/badge.svg" alt="Build status">
+  <a href="https://github.com/fingerprintjs/gtm-integration/actions/workflows/build.yml">
+    <img src="https://github.com/fingerprintjs/gtm-integration/actions/workflows/build.yml/badge.svg" alt="Build status">
   </a>
 </p>
 
@@ -23,7 +23,7 @@ For step-by-step instructions on using this integration, see the full [Google Ta
 ## Usage
 
 1. [Sign up](https://dashboard.fingerprint.com/signup) for a Fingerprint Pro account if you haven't already.
-2. Import this `template.tpl` from [latest release](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/releases) into your Google Tag Manager workspace.
+2. Import this `template.tpl` from [latest release](https://github.com/fingerprintjs/gtm-integration/releases) into your Google Tag Manager workspace.
 3. Add a Fingerprint Pro tag to your website. You will need your public API key and workspace region.
 4. Use the `FingerprintResult` or your own *Custom result name* to access the Fingerprint Pro result in GTM's `dataLayer`.
 5. Use the `Fingerprint.started` and `Fingerprint.identified` event names to create custom events and trigger actions after the JS agent is loaded or the visitor is identified.
@@ -57,9 +57,9 @@ Ad-blocking browser extensions such as AdBlock, uBlock Origin, etc., can block a
 
 ## Support and Feedback
 
-To report problems, ask questions, or provide feedback, please use [Issues](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/issues). 
+To report problems, ask questions, or provide feedback, please use [Issues](https://github.com/fingerprintjs/gtm-integration/issues). 
 If you need private support, you can email us at [oss-support@fingerprint.com](mailto:oss-support@fingerprint.com).
 
 ## License
 
-This project is licensed under the [Apache 2.0 license](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/blob/main/LICENSE).
+This project is licensed under the [Apache 2.0 license](https://github.com/fingerprintjs/gtm-integration/blob/main/LICENSE).

--- a/contributing.md
+++ b/contributing.md
@@ -24,7 +24,7 @@ const onSuccess = () => {
     data.gtmOnSuccess();
   };
 
-  callInWindow('FingerprintjsProGTM.load', {apiKey: data.apiKey}, onFpJsLoad);
+  callInWindow('FingerprintGTM.load', {apiKey: data.apiKey}, onFpJsLoad);
 };
 
 // If the script fails to load, log a message and signal failure

--- a/contributing.md
+++ b/contributing.md
@@ -2,7 +2,7 @@
 
 Since GTM ([Google Tag Manager](https://tagmanager.google.com/)) uses a subset of the [JavaScript API](https://developers.google.com/tag-platform/tag-manager/templates/sandboxed-javascript) that doesn't support `Promises`, we created this adapter for the [FingerprintJS JS agent](https://docs.fingerprint.com/reference/js-agent-v4) that can be used in a GTM template.
 
-The adapter code is hosted on CDN and accessible at `https://opencdn.fpjs.sh/fingerprintjs-pro-gtm/v1/iife.min.js`.
+The adapter code is hosted on CDN and accessible at `https://opencdn.fpjs.sh/gtm-adapter/v2/iife.min.js`.
 See the [CDN repository](https://github.com/fingerprintjs/cdn) for more information.
 
 ## Usage example
@@ -12,7 +12,7 @@ In the GTM template, load the adapter from the CDN:
 ```javascript
 const injectScript = require('injectScript');
 const callInWindow = require('callInWindow');
-const url = `https://opencdn.fpjs.sh/fingerprintjs-pro-gtm/v1/iife.min.js`;
+const url = `https://opencdn.fpjs.sh/gtm-adapter/v2/iife.min.js`;
 
 const onSuccess = () => {
   const onFpJsLoad = (result) => {

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -4,7 +4,7 @@ versions:
   - sha: 60138b9e1212bbfa3060169f7d31dde79df1c80a
     changeNotes: >+
       ##
-      [1.1.0](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/compare/v1.0.0...v1.1.0)
+      [1.1.0](https://github.com/fingerprintjs/gtm-integration/compare/v1.0.0...v1.1.0)
       (2024-03-28)
 
 
@@ -13,10 +13,10 @@ versions:
 
 
       * add identification request timing
-      ([2c97d3e](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/2c97d3e4caf95423a961554caa25ed81a1ad9c39))
+      ([2c97d3e](https://github.com/fingerprintjs/gtm-integration/commit/2c97d3e4caf95423a961554caa25ed81a1ad9c39))
 
       * create tag version with 3 roles: load, identify and load + identify
-      ([4ae0f7b](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/4ae0f7b90bbbf25f7c93aa809a76e5e153b4b160))
+      ([4ae0f7b](https://github.com/fingerprintjs/gtm-integration/commit/4ae0f7b90bbbf25f7c93aa809a76e5e153b4b160))
 
 
 
@@ -24,7 +24,7 @@ versions:
 
 
       * show tag settings depends on tag type
-      ([b77ddba](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/b77ddba7e55cc43aedd99adbc6b044159ea29bcb))
+      ([b77ddba](https://github.com/fingerprintjs/gtm-integration/commit/b77ddba7e55cc43aedd99adbc6b044159ea29bcb))
 
 
 
@@ -32,13 +32,13 @@ versions:
 
 
       * **README:** add description to the  template field
-      ([dc4b3b2](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/dc4b3b24cfc422fe8077b6023f9592782ed0dba3))
+      ([dc4b3b2](https://github.com/fingerprintjs/gtm-integration/commit/dc4b3b24cfc422fe8077b6023f9592782ed0dba3))
 
       * **README:** remove beta warning
-      ([c3c13dc](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/c3c13dc401f45d58b92ca0f6755ef492f33ba9d2))
+      ([c3c13dc](https://github.com/fingerprintjs/gtm-integration/commit/c3c13dc401f45d58b92ca0f6755ef492f33ba9d2))
 
       * **README:** update readme
-      ([7e46ee5](https://github.com/fingerprintjs/fingerprintjs-pro-gtm/commit/7e46ee5c68acf03f9cc4cf054cc26775d39ecc10))
+      ([7e46ee5](https://github.com/fingerprintjs/gtm-integration/commit/7e46ee5c68acf03f9cc4cf054cc26775d39ecc10))
 
   - sha: 311c586050a95aff5e7d0dd0fcae6688c01d043a
     changeNotes: Allow using `tagType` to load the script and identify visitor

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@fingerprintjs/fingerprintjs-pro-gtm",
   "version": "1.1.0",
-  "description": "FingerprintJS pro version adapter for Google Tag Manager",
+  "description": "Fingerprint JS agent adapter for Google Tag Manager",
   "author": "FingerprintJS, Inc (https://fingerprint.com)",
   "license": "Apache-2.0",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "changeset:version": "changeset version",
     "changeset:publish": "HUSKY=0 changeset publish"
   },
-  "module": "dist/fpjs-pro-gtm.esm.js",
+  "module": "dist/fp-gtm-adapter.esm.js",
   "files": [
     "dist"
   ],

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "private": true,
   "repository": {
     "type": "git",
-    "url": "https://github.com/fingerprintjs/fingerprintjs-pro-gtm.git"
+    "url": "https://github.com/fingerprintjs/gtm-integration.git"
   },
   "scripts": {
     "build": "rimraf dist && rollup -c --bundleConfigAsCjs",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@fingerprintjs/fingerprintjs-pro-gtm",
+  "name": "@fingerprint/gtm-adapter",
   "version": "1.1.0",
   "description": "Fingerprint JS agent adapter for Google Tag Manager",
   "author": "FingerprintJS, Inc (https://fingerprint.com)",

--- a/resources/license_banner.txt
+++ b/resources/license_banner.txt
@@ -1,2 +1,2 @@
-FingerprintJS Pro GTM v<%= pkg.version %> - Copyright (c) FingerprintJS, Inc, <%= new Date().getFullYear() %> (https://fingerprint.com)
+Fingerprint GTM Adapter v<%= pkg.version %> - Copyright (c) FingerprintJS, Inc, <%= new Date().getFullYear() %> (https://fingerprint.com)
 Licensed under the Apache 2.0 (http://www.opensource.org/licenses/mit-license.php) license.

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ import { join } from 'path'
 
 const inputFile = 'src/index.ts'
 const outputDirectory = 'dist'
-const artifactName = 'fpjs-pro-gtm'
+const artifactName = 'fp-gtm-adapter'
 
 const commonBanner = licensePlugin({
   banner: {
@@ -22,7 +22,7 @@ const commonInput = {
 }
 
 const commonOutput = {
-  name: 'FingerprintjsProGTM',
+  name: 'FingerprintGTM',
   exports: 'named',
 }
 

--- a/template.tpl
+++ b/template.tpl
@@ -218,7 +218,7 @@ const createQueue = require('createQueue');
 const copyFromWindow = require('copyFromWindow');
 const getTimestampMillis = require('getTimestampMillis');
 
-const url = 'https://opencdn.fpjs.sh/fingerprintjs-pro-gtm/v1/iife.min.js';
+const url = 'https://opencdn.fpjs.sh/gtm-adapter/v2/iife.min.js';
 
 log('data =', data);
 
@@ -350,7 +350,7 @@ ___WEB_PERMISSIONS___
             "listItem": [
               {
                 "type": 1,
-                "string": "https://opencdn.fpjs.sh/fingerprintjs-pro-gtm/v1/iife.min.js"
+                "string": "https://opencdn.fpjs.sh/gtm-adapter/v2/iife.min.js"
               }
             ]
           }


### PR DESCRIPTION
- Update references to repo to use new name
- Remove references to FP Pro
- Rename package to `@fingerprint/gtm-adapter`
- Update rollup build to rename output to `fp-gtm-adapter.esm.js`
- Update adapter script URLs to use the new CDN URLs for the script