### PR TITLE
chore: remove `private` from package.json

### DIFF
--- a/.changeset/clear-kings-happen.md
+++ b/.changeset/clear-kings-happen.md
@@ -1,0 +1,5 @@
+---
+'@fingerprint/gtm-adapter': patch
+---
+
+Remove `private` property from package.json. This is a temporary changeset to trigger the next prerelease.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "Fingerprint JS agent adapter for Google Tag Manager",
   "author": "FingerprintJS, Inc (https://fingerprint.com)",
   "license": "Apache-2.0",
-  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/fingerprintjs/gtm-integration.git"


### PR DESCRIPTION
- Remove `private` from package.json. Changesets will not publish private packages to NPM so this needs to be removed to publish the adapter to NPM.